### PR TITLE
Bugfix/issue 20 bug book field

### DIFF
--- a/server/books/models.py
+++ b/server/books/models.py
@@ -145,7 +145,7 @@ class BookEntry(models.Model):
         )
 
     def __str__(self) -> str:
-        return f"{self.user.username} - {self.book.title}"
+        return f"{self.profile.user.username} - {self.book.title}"
 
 
 class Collection(models.Model):
@@ -175,4 +175,4 @@ class Collection(models.Model):
     objects = models.Manager()
 
     def __str__(self) -> str:
-        return self.title
+        return f"{self.title} - {self.profile.user.username}"

--- a/server/books/serializers.py
+++ b/server/books/serializers.py
@@ -24,7 +24,6 @@ class UserSerializer(serializers.ModelSerializer):
         """
         model = User
         fields = (
-            'id',
             'username',
             'first_name',
             'last_name',
@@ -57,7 +56,8 @@ class BookEntrySerializer(serializers.ModelSerializer):
         model = BookEntry
         exclude = (
             'profile',
-            'datetime_added'
+            'datetime_added',
+            'id',
         )
 
 
@@ -99,7 +99,7 @@ class ProfileSerializer(serializers.ModelSerializer):
         Metadata class
         """
         model = Profile
-        fields = '__all__'
+        exclude = ('id',)
 
 
 class PrivateProfileSerializer(serializers.ModelSerializer):

--- a/server/books/serializers.py
+++ b/server/books/serializers.py
@@ -74,7 +74,7 @@ class CollectionSerializer(serializers.ModelSerializer):
         """
         model = Collection
         exclude = (
-            'profile'
+            'profile',
         )
 
 
@@ -85,7 +85,8 @@ class ProfileSerializer(serializers.ModelSerializer):
 
     user = UserSerializer(read_only=True)
     favorite_book = BookSerializer(required=False)
-    book_list = BookEntrySerializer(many=True, read_only=True)
+    book_list = BookEntrySerializer(source='bookentry_set', many=True, read_only=True)
+    collections = CollectionSerializer(many=True)
 
     private = serializers.BooleanField(required=False)
     profile_picture = serializers.ImageField(

--- a/server/books/urls.py
+++ b/server/books/urls.py
@@ -20,6 +20,6 @@ urlpatterns = [
 
     # Collection URLs
     path('<str:username>/collections', ManageUserCollections.as_view()),
-    path('<str:username>/collections/<int:collection_id>',
+    path('<str:username>/collections/<str:collection_uuid>',
          ManageUserCollectionDetail.as_view()),
 ]

--- a/server/books/views.py
+++ b/server/books/views.py
@@ -273,7 +273,6 @@ class ManageBookEntryDetail(APIView):
 
         data = request.data
 
-        # TODO : Validate current page
         current_page = data.get('current_page')
         book_status = data.get('status')
         book_rating = data.get('rating')
@@ -341,7 +340,7 @@ class ManageUserCollectionDetail(APIView):
             collection = get_object_or_404(
                 Collection, uuid=collection_uuid, profile=user_profile)
 
-            serializer = CollectionSerializer(collection, many=True)
+            serializer = CollectionSerializer(collection, many=False)
             return Response(
                 serializer.data,
                 status=status.HTTP_200_OK


### PR DESCRIPTION
# Fixes

- Fixed #20 
- Removed `id` for different objects in the serialized data
- Fixed `GET` collection detail bug and URL
- Below is an example response of a user profile

```json
{
    "user": {
        "username": "test",
        "first_name": "First",
        "last_name": "Customer"
    },
    "favorite_book": {
        "id": 1,
        "title": "Oshi no Ko 01",
        "author": "Aka Akasaka",
        "isbn": "9788419185143",
        "page_count": 200,
        "publication_date": "2022-02-03",
        "cover_image": "https://covers.openlibrary.org/b/id/13480250-L.jpg"
    },
    "book_list": [
        {
            "book": {
                "id": 1,
                "title": "Oshi no Ko 01",
                "author": "Aka Akasaka",
                "isbn": "9788419185143",
                "page_count": 200,
                "publication_date": "2022-02-03",
                "cover_image": "https://covers.openlibrary.org/b/id/13480250-L.jpg"
            },
            "current_page": 0,
            "status": "Not Started",
            "rating": 1,
            "last_updated": "2023-05-17T04:10:55.643751Z"
        }
    ],
    "collections": [
        {
            "uuid": "204722b1-9405-46a7-8726-432b8ff9fdd0",
            "books": [
                {
                    "id": 1,
                    "title": "Oshi no Ko 01",
                    "author": "Aka Akasaka",
                    "isbn": "9788419185143",
                    "page_count": 200,
                    "publication_date": "2022-02-03",
                    "cover_image": "https://covers.openlibrary.org/b/id/13480250-L.jpg"
                }
            ],
            "title": "Title",
            "description": "fasldk"
        }
    ],
    "private": false,
    "profile_picture": "/media/images/jed.png"
}
```